### PR TITLE
added DESTDIR to Makefiles

### DIFF
--- a/src/tools/Makefile
+++ b/src/tools/Makefile
@@ -17,12 +17,12 @@ clean:
 	rm ../../bin/wcch -f
 
 install:
-	cp wldd /usr/bin/wldd
-	cp wcch /usr/bin/wcch
+	cp wldd $(DESTDIR)/usr/bin/wldd
+	cp wcch $(DESTDIR)/usr/bin/wcch
 
 uninstall:
-	rm /usr/bin/wldd -f
-	rm /usr/bin/wcch -f
+	rm $(DESTDIR)/usr/bin/wldd -f
+	rm $(DESTDIR)/usr/bin/wcch -f
 
 
 

--- a/src/wcc/Makefile
+++ b/src/wcc/Makefile
@@ -43,9 +43,9 @@ clean:
 	rm -f wcc a.out wcc.o core wcc32 ls.o ls.so
 
 install:
-	cp wcc /usr/bin/wcc
-#	cp wcc32 /usr/bin/wcc32
+	cp wcc $(DESTDIR)/usr/bin/wcc
+#	cp wcc32 $(DESTDIR)/usr/bin/wcc32
 
 uninstall:
-	rm /usr/bin/wcc -f
-#	rm /usr/bin/wcc32 -f
+	rm $(DESTDIR)/usr/bin/wcc -f
+#	rm $(DESTDIR)/usr/bin/wcc32 -f

--- a/src/wld/Makefile
+++ b/src/wld/Makefile
@@ -31,9 +31,9 @@ clean:
 	rm -f wld wld32 a.out
 
 install:
-	cp wld /usr/bin/wld
-#	cp wld32 /usr/bin/wld32
+	cp wld $(DESTDIR)/usr/bin/wld
+#	cp wld32 $(DESTDIR)/usr/bin/wld32
 
 uninstall:
-	rm /usr/bin/wld -f
-#	rm /usr/bin/wld32 -f
+	rm $(DESTDIR)/usr/bin/wld -f
+#	rm $(DESTDIR)/usr/bin/wld32 -f

--- a/src/wsh/Makefile
+++ b/src/wsh/Makefile
@@ -44,13 +44,13 @@ deepclean:
 	make clean
 
 install::
-	mkdir -p /usr/share/wcc/
-	cp -r ./scripts /usr/share/wcc/
-	cp wsh /usr/bin/wsh
+	mkdir -p $(DESTDIR)/usr/share/wcc/
+	cp -r ./scripts $(DESTDIR)/usr/share/wcc/
+	cp wsh $(DESTDIR)/usr/bin/wsh
 
 uninstall::
-	rm -rf /usr/share/wcc/
-	rm -f /usr/bin/wsh
+	rm -rf $(DESTDIR)/usr/share/wcc/
+	rm -f $(DESTDIR)/usr/bin/wsh
 
 binfmt:
 	sudo update-binfmts --install wsh /usr/bin/wsh --extension wsh

--- a/src/wsh/Makefile-i386
+++ b/src/wsh/Makefile-i386
@@ -49,10 +49,10 @@ deepclean:
 	make clean
 
 install::
-	mkdir -p /usr/share/wcc/
-	cp -r ./scripts /usr/share/wcc/
-	cp wsh-i386 /usr/bin/wsh-i386
+	mkdir -p $(DESTDIR)/usr/share/wcc/
+	cp -r ./scripts $(DESTDIR)/usr/share/wcc/
+	cp wsh-i386 $(DESTDIR)/usr/bin/wsh-i386
 
 uninstall::
-	rm -rf /usr/share/wcc/
-	rm -f /usr/bin/wsh-i386
+	rm -rf $(DESTDIR)/usr/share/wcc/
+	rm -f $(DESTDIR)/usr/bin/wsh-i386


### PR DESCRIPTION
Adding DESTDIR gives the user ability to install/uninstall files in another chosen directory instead of the usual /usr/bin (useful for installing on chroots or while packaging for ArchLinux)

Example:
```
make DESTDIR=$CHROOT install
```
Where $CHROOT can be a pointer to any directory the user wishes to install.