### PR TITLE
Check ret is valid with dlerror() or get a segfault.

### DIFF
--- a/src/wsh/wsh.c
+++ b/src/wsh/wsh.c
@@ -231,6 +231,7 @@ static unsigned long int resolve_addr(char *symbol, char *libname)
 	unsigned long int ret = 0;
 	struct link_map *handle;
 	Dl_info dli;
+  char *err = 0;
 
 	if ((!symbol) || (!*symbol)) {
 		return -1;
@@ -245,6 +246,14 @@ static unsigned long int resolve_addr(char *symbol, char *libname)
 	dlerror();		/* Clear any existing error */
 
 	ret = (unsigned long int) dlsym(handle, symbol);
+
+  /* Check dlerror() since ret == NULL is ok. */
+  err = dlerror();
+
+  if (err) {
+    fprintf(stderr, "ERROR: %s\n", err);
+    //_Exit(EXIT_FAILURE);
+  }
 
 	dladdr((void *) ret, &dli);
 


### PR DESCRIPTION
 Linux x86_64 would SIGSEGV . The man page for dlopen() said to check the result this way.

