### PR TITLE
wsh: fix a crash when a symbol can't be loaded

### DIFF
--- a/src/wsh/wsh.c
+++ b/src/wsh/wsh.c
@@ -254,17 +254,22 @@ static unsigned long int resolve_addr(char *symbol, char *libname)
 
 	ret = (unsigned long int) dlsym(handle, symbol);
 
+	if (!ret) {
 #ifdef PEDANTIC_WARNINGS
-	/* Check dlerror() since ret == NULL is ok. */
-	char *err = 0;
-	err = dlerror();
+		char *err = 0;
+		err = dlerror();
 
-	if (err) {
-		fprintf(stderr, "ERROR: %s\n", err);
-		//_Exit(EXIT_FAILURE);
+		if (err) {
+			fprintf(stderr, "ERROR: %s\n", err);
+			//_Exit(EXIT_FAILURE);
+		}
+#endif
+		/* Ignore the symbol */
+		dlclose(handle);
+
+		return -1;
 	}
 
-#endif
 	dladdr((void *) ret, &dli);
 
 	// Is it the correct lib ?


### PR DESCRIPTION
In case a symbol can be loaded dlsym() returns NULL. This need to be handled instead of blindly passing the 0 address do dladdr(), otherwise that causes a crash:

$ ./bin/wsh
init
WARNING: No binary loaded in memory. Try loadbin(). For help type help("loadbin").

[SIGSEGV]       Read    0x19        (address not mapped to object)
        0x7f7edd231cb1    /lib/x86_64-linux-gnu/libc.so.6(+0x14fcb1)
        0x42017f52    ./bin/wsh(scan_syms+0x152)
        0x420183c8    ./bin/wsh(parse_link_map_dyn+0x58)
        0x4201c371    ./bin/wsh(wsh_run+0x61)
        0x4200ecba    ./bin/wsh(main+0x3a)
        0x7f7edd10520a    /lib/x86_64-linux-gnu/libc.so.6(+0x2320a)
        0x7f7edd1052bc    /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x7c)
        0x4200ed0a    ./bin/wsh(_start+0x2a)
Segmentation fault (core dumped)

This is reproducible for instance when wsh has been built against glibc <= 2.33, but executed on glibc >= 2.34. This is due to the merge of libdl.so into libc.so, resulting in libdl.so only containing weak symbols. wsh then crashes when trying to dlsym the _ITM_deregisterTMCloneTable symbol.

Rebuilding wcc against glibc >= 2.34 workarounds the problem as the resulting wsh binary is not linked against libdl.so anymore.