### PR TITLE
Fix typo in wld/Makefile

### DIFF
--- a/src/wld/Makefile
+++ b/src/wld/Makefile
@@ -13,7 +13,7 @@
 # the 32b library on top of a 64b system using apt-get breaks ubuntu.
 #
 # Note that the 64b version and 32b versions alike can process
-# any ELF (from any architecture/OS/endianess).
+# any ELF (from any architecture/OS/endianness).
 #
 
 CFLAGS	:= -W -Wall -Wno-discarded-qualifiers -Wno-int-conversion -Wno-unused-parameter -Wno-unused-function -Wno-unused-result -fpie -pie -fPIC -g3 -ggdb -I../../include  -I./include/sflib/ -I./include -I../../include/  -Wno-incompatible-pointer-types  -fstack-protector-all -Wl,-z,relro,-z,now -DPACKAGE -DPACKAGE_VERSION -masm=intel -rdynamic -D_FORTIFY_SOURCE=2 -O2


### PR DESCRIPTION
Fix small typo in comment section of `wld/Makefile`