### PR TITLE
Fix build with gcc-14

### DIFF
--- a/src/wsh/wsh.c
+++ b/src/wsh/wsh.c
@@ -37,6 +37,11 @@
 #include <utlist.h>
 #include <libgen.h>	// For basename()
 #include <lauxlib.h>
+#include <sys/sendfile.h> // For sendfile()
+
+// Forward declarations
+int wsh_usage(char *name);
+int wsh_print_version(void);
 
 // address sanitizer macro : disable a function by prepending ATTRIBUTE_NO_SANITIZE_ADDRESS to its definition
 #if defined(__clang__) || defined (__GNUC__)


### PR DESCRIPTION
A rebuild of the Ubuntu package failed with gcc-14. And the errors were:

```
wsh.c:4898:18: error: implicit declaration of function ‘sendfile’ [-Wimplicit-function-declaration]
 4898 |         copied = sendfile(fdout, fdin, 0, sb.st_size);
      |                  ^~~~~~~~
```
```
wsh.c: In function ‘wsh_getopt’:
wsh.c:5013:25: error: implicit declaration of function ‘wsh_usage’ [-Wimplicit-function-declaration]
 5013 |                         wsh_usage(argv[0]);
      |                         ^~~~~~~~~
wsh.c:5026:25: error: implicit declaration of function ‘wsh_print_version’; did you mean ‘print_version’? [-Wimplicit-function-declaration]
 5026 |                         wsh_print_version();
      |                         ^~~~~~~~~~~~~~~~~
      |                         print_version
```